### PR TITLE
[#35] User 타입 enum으로 변경

### DIFF
--- a/src/main/java/com/flab/kidsafer/config/auth/dto/SessionUser.java
+++ b/src/main/java/com/flab/kidsafer/config/auth/dto/SessionUser.java
@@ -2,6 +2,7 @@ package com.flab.kidsafer.config.auth.dto;
 
 import com.flab.kidsafer.domain.enums.Status;
 import com.flab.kidsafer.domain.User;
+import com.flab.kidsafer.domain.enums.UserType;
 import java.io.Serializable;
 
 public class SessionUser implements Serializable {
@@ -10,7 +11,7 @@ public class SessionUser implements Serializable {
 
     private int id;
     private String email;
-    private String type;
+    private UserType type;
     private Status status;
 
     public SessionUser(User user) {
@@ -28,7 +29,7 @@ public class SessionUser implements Serializable {
         return email;
     }
 
-    public String getType() {
+    public UserType getType() {
         return type;
     }
 

--- a/src/main/java/com/flab/kidsafer/controller/PostController.java
+++ b/src/main/java/com/flab/kidsafer/controller/PostController.java
@@ -2,6 +2,7 @@ package com.flab.kidsafer.controller;
 
 import com.flab.kidsafer.config.auth.LoginUser;
 import com.flab.kidsafer.config.auth.dto.SessionUser;
+import com.flab.kidsafer.domain.enums.UserType;
 import com.flab.kidsafer.dto.PostDTO;
 import com.flab.kidsafer.error.exception.OperationNotAllowedException;
 import com.flab.kidsafer.service.PostService;
@@ -32,7 +33,7 @@ public class PostController {
 
     @PostMapping
     public void registerPost(@RequestBody @Valid PostDTO postDTO, @LoginUser SessionUser user) {
-        if(!"PARENT".equals(user.getType()))  //TODO : enum타입으로 변경 예정
+        if(user.getType() != UserType.PARENT)
             throw new OperationNotAllowedException();
         postService.registerPost(postDTO);
     }

--- a/src/main/java/com/flab/kidsafer/domain/User.java
+++ b/src/main/java/com/flab/kidsafer/domain/User.java
@@ -1,6 +1,7 @@
 package com.flab.kidsafer.domain;
 
 import com.flab.kidsafer.domain.enums.Status;
+import com.flab.kidsafer.domain.enums.UserType;
 import java.time.LocalDateTime;
 import java.util.UUID;
 
@@ -11,14 +12,14 @@ public class User {
     private String email;
     private String nickname;
     private String phone;
-    private String type;
+    private UserType type;
     private Status status;
     private String emailCheckToken;
 
     private LocalDateTime emailCheckTokenGeneratedAt;
 
     public User(int userId, String password, String email, String nickname, String phone,
-        String type,
+        UserType type,
         Status status) {
         this.userId = userId;
         this.password = password;
@@ -78,11 +79,11 @@ public class User {
         this.phone = phone;
     }
 
-    public String getType() {
+    public UserType getType() {
         return type;
     }
 
-    public void setType(String type) {
+    public void setType(UserType type) {
         this.type = type;
     }
 
@@ -108,10 +109,10 @@ public class User {
         private String password;
         private String nickname;
         private String phone;
-        private String type;
+        private UserType type;
         private Status status;
 
-        public Builder(String email, String password, String type) {
+        public Builder(String email, String password, UserType type) {
             this.email = email;
             this.password = password;
             this.type = type;

--- a/src/main/java/com/flab/kidsafer/domain/UserDto.java
+++ b/src/main/java/com/flab/kidsafer/domain/UserDto.java
@@ -1,6 +1,7 @@
 package com.flab.kidsafer.domain;
 
 import com.flab.kidsafer.domain.enums.Status;
+import com.flab.kidsafer.domain.enums.UserType;
 import javax.validation.constraints.Email;
 import javax.validation.constraints.NotNull;
 import javax.validation.constraints.Pattern;
@@ -25,12 +26,12 @@ public class UserDto {
     private String phone;
 
     @NotNull(message = "Null은 포함될 수 없습니다.")
-    private String type;
+    private UserType type;
 
     private Status status;
 
     public UserDto(String email, String password, String nickname, String phone,
-        String type, Status status) {
+        UserType type, Status status) {
         this.email = email;
         this.password = password;
         this.nickname = nickname;
@@ -54,7 +55,7 @@ public class UserDto {
         private String password;
         private String nickname;
         private String phone;
-        private String type;
+        private UserType type;
         private Status status;
 
         public Builder Builder() {
@@ -70,8 +71,8 @@ public class UserDto {
             this.password = password;
             return this;
         }
-
-        public UserDto.Builder type(String type) {
+        
+        public UserDto.Builder type(UserType type) {
             this.type = type;
             return this;
         }
@@ -112,7 +113,7 @@ public class UserDto {
         return phone;
     }
 
-    public String getType() {
+    public UserType getType() {
         return type;
     }
 

--- a/src/main/java/com/flab/kidsafer/domain/enums/UserType.java
+++ b/src/main/java/com/flab/kidsafer/domain/enums/UserType.java
@@ -1,0 +1,31 @@
+package com.flab.kidsafer.domain.enums;
+
+import com.flab.kidsafer.mybatis.handler.CodeEnumTypeHandler;
+import org.apache.ibatis.type.MappedTypes;
+import org.springframework.stereotype.Component;
+
+public enum UserType implements CodeEnum {
+  PARENT("PARENT"),
+  SAFER("SAFER"),
+  ADMIN("ADMIN");
+
+  private final String value;
+
+  UserType(String value) {
+    this.value = value;
+  }
+
+  @Override
+  public String getCode() {
+    return String.valueOf(value);
+  }
+
+  @Component
+  @MappedTypes(UserType.class)
+  public static class TypeHandler extends CodeEnumTypeHandler<UserType> {
+
+    public TypeHandler() {
+      super(UserType.class);
+    }
+  }
+}

--- a/src/test/java/com/flab/kidsafer/controller/PostControllerTest.java
+++ b/src/test/java/com/flab/kidsafer/controller/PostControllerTest.java
@@ -10,6 +10,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.flab.kidsafer.config.auth.dto.SessionUser;
 import com.flab.kidsafer.domain.enums.Status;
 import com.flab.kidsafer.domain.User;
+import com.flab.kidsafer.domain.enums.UserType;
 import com.flab.kidsafer.dto.PostDTO;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
@@ -57,7 +58,7 @@ class PostControllerTest {
 
     @BeforeEach
     public void setSessionUser() {
-        user = new User(1, "1234", "test@test", "test", "test", "PARENT", Status.DEFAULT);
+        user = new User(1, "1234", "test@test", "test", "test", UserType.PARENT, Status.DEFAULT);
         loginUser = new SessionUser(user);
         session = new MockHttpSession();
         session.setAttribute("user", loginUser);
@@ -78,7 +79,7 @@ class PostControllerTest {
     public void getOnePost_failure() throws Exception {
         mockMvc.perform(get("/posts/9999")
             .contentType(MediaType.APPLICATION_JSON))
-            .andExpect(status().isBadRequest())
+            .andExpect(status().isNotFound())
             .andDo(print());
 
     }

--- a/src/test/java/com/flab/kidsafer/controller/PostLikeControllerTest.java
+++ b/src/test/java/com/flab/kidsafer/controller/PostLikeControllerTest.java
@@ -7,6 +7,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 
 import com.flab.kidsafer.config.auth.dto.SessionUser;
 import com.flab.kidsafer.domain.User;
+import com.flab.kidsafer.domain.enums.UserType;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -17,18 +18,20 @@ import org.springframework.http.MediaType;
 import org.springframework.mock.web.MockHttpSession;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.context.WebApplicationContext;
 import org.springframework.web.filter.CharacterEncodingFilter;
 
 @SpringBootTest
 @AutoConfigureMockMvc
+@Transactional
 public class PostLikeControllerTest {
 
     private static int INVALID_POSTID = -999;
     private static int VALID_POSTID = 1;
-    private static int ALREADY_LIKE_POSTID = 2;
+    private static int ALREADY_LIKE_POSTID = 1;
     private static int DELETED_LIKE_POSTID = 3;
-    private static int TOBE_DELETED_LIKE_POSTID = 4;
+    private static int TOBE_DELETED_LIKE_POSTID = 1;
 
     @Autowired
     private MockMvc mockMvc;
@@ -49,7 +52,7 @@ public class PostLikeControllerTest {
 
     @BeforeEach
     public void setSessionUserAndPostId() {
-        User user = new User(1, "1234", "test@test", "test", "test", "PARENT", "DEFAULT");
+        User user = new User(1, "1234", "test@test", "test", "test", UserType.PARENT, "DEFAULT");
         loginUser = new SessionUser(user);
         session = new MockHttpSession();
         session.setAttribute("user", loginUser);
@@ -58,12 +61,6 @@ public class PostLikeControllerTest {
     @Test
     @DisplayName("좋아요 성공")
     public void like_success() throws Exception {
-        /* 기존 좋아요 내역 취소 */
-        mockMvc.perform(delete("/posts/{postId}/likes", VALID_POSTID)
-            .contentType(MediaType.APPLICATION_JSON)
-            .session(session))
-            .andExpect(status().isOk())
-            .andDo(print());
         mockMvc.perform(post("/posts/{postId}/likes", VALID_POSTID)
             .contentType(MediaType.APPLICATION_JSON)
             .session(session))
@@ -75,6 +72,11 @@ public class PostLikeControllerTest {
     @Test
     @DisplayName("이미 좋아요를 한 post에 다시 좋아요 시도해 실패")
     public void like_failure1() throws Exception {
+        mockMvc.perform(post("/posts/{postId}/likes", ALREADY_LIKE_POSTID)
+            .contentType(MediaType.APPLICATION_JSON)
+            .session(session))
+            .andExpect(status().isOk())
+            .andDo(print());
         mockMvc.perform(post("/posts/{postId}/likes", ALREADY_LIKE_POSTID)
             .contentType(MediaType.APPLICATION_JSON)
             .session(session))

--- a/src/test/java/com/flab/kidsafer/controller/UserControllerTest.java
+++ b/src/test/java/com/flab/kidsafer/controller/UserControllerTest.java
@@ -11,6 +11,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.flab.kidsafer.domain.SignInRequest;
 import com.flab.kidsafer.domain.User;
+import com.flab.kidsafer.domain.enums.UserType;
 import com.flab.kidsafer.error.exception.TokenInvalidException;
 import com.flab.kidsafer.error.exception.UserNotSignInException;
 import com.flab.kidsafer.mapper.UserMapper;
@@ -145,7 +146,7 @@ class UserControllerTest {
     @Test
     @DisplayName("인증 메일 확인 - 입력값 정상")
     void checkEmailToken() throws Exception {
-        User user = new User.Builder("test@email.com", "12345678", "ADMIN")
+        User user = new User.Builder("test@email.com", "12345678", UserType.ADMIN)
             .nickname("leejun")
             .build();
         user.setPassword(SHA256Util.getSHA256(user.getPassword()));

--- a/src/test/java/com/flab/kidsafer/service/PostLikeServiceTest.java
+++ b/src/test/java/com/flab/kidsafer/service/PostLikeServiceTest.java
@@ -9,6 +9,7 @@ import static org.mockito.Mockito.when;
 
 import com.flab.kidsafer.domain.PostLike;
 import com.flab.kidsafer.domain.User;
+import com.flab.kidsafer.domain.enums.UserType;
 import com.flab.kidsafer.dto.PostDTO;
 import com.flab.kidsafer.error.exception.PostNotFoundException;
 import com.flab.kidsafer.error.exception.UserNotFoundException;
@@ -52,7 +53,7 @@ class PostLikeServiceTest {
     }
 
     public User generateUser() {
-        return new User.Builder("test", "test", "test").build();
+        return new User.Builder("test", "test", UserType.PARENT).build();
     }
 
     public PostDTO generatePost() {

--- a/src/test/java/com/flab/kidsafer/service/UserServiceTest.java
+++ b/src/test/java/com/flab/kidsafer/service/UserServiceTest.java
@@ -2,6 +2,7 @@ package com.flab.kidsafer.service;
 
 import com.flab.kidsafer.domain.SignInRequest;
 import com.flab.kidsafer.domain.User;
+import com.flab.kidsafer.domain.enums.UserType;
 import com.flab.kidsafer.dto.UserUpdateInfoRequest;
 import com.flab.kidsafer.dto.UserUpdatePasswordRequest;
 import com.flab.kidsafer.error.exception.OperationNotAllowedException;
@@ -54,7 +55,7 @@ class UserServiceTest {
         SignInRequest loginRequest = new SignInRequest("cjk@gmail.com", "1234!abc");
         when(userMapper.findByEmailAndPassword(loginRequest.getEmail(),
             SHA256Util.getSHA256(loginRequest.getPassword())))
-            .thenReturn(new User.Builder("cjk@gmail.com", "1234!abc", "A").build());
+            .thenReturn(new User.Builder("cjk@gmail.com", "1234!abc", UserType.PARENT).build());
 
         //when
         User user = userService.signIn(loginRequest);
@@ -99,7 +100,7 @@ class UserServiceTest {
             .setUserId(1).setNickname("테스트").setPhone("010-1234-5670").build();
         int userId = 1;
         when(userMapper.findById(userUpdateInfoRequest.getUserId()))
-            .thenReturn(new User.Builder("cjk@gmail.com", "1234!abc", "A").build());
+            .thenReturn(new User.Builder("cjk@gmail.com", "1234!abc", UserType.PARENT).build());
 
         //when
         userService.modifyUserInfo(userUpdateInfoRequest, userId);
@@ -116,7 +117,7 @@ class UserServiceTest {
             .setUserId(1).setCurrentPassword("xptmxm").setModifiedPassword("xptmxm").build();
         int userId = 1;
         when(userMapper.findById(userUpdatePasswordRequest.getUserId()))
-            .thenReturn(new User.Builder("cjk@gmail.com", "1234!abc", "A").build());
+            .thenReturn(new User.Builder("cjk@gmail.com", "1234!abc", UserType.PARENT).build());
 
         //then
         assertThrows(PasswordInputInvalidException.class,
@@ -138,7 +139,7 @@ class UserServiceTest {
 
         when(userMapper.findById(userUpdatePasswordRequest.getUserId()))
             .thenReturn((new User.Builder("cjk@gmail.com",
-                encryptPassword, "A")
+                encryptPassword, UserType.PARENT)
                 .build()));
         doNothing().when(userMapper)
             .updateUserPassword(userUpdatePasswordRequest.getUserId(), encryptModiPassword);


### PR DESCRIPTION
### 이슈번호
#35 

### 구현기능
* User의 Type(부모, 등하원도우미, 관리자)를 Enum으로 적용할 수 있도록 변경
* 관련 테스트코드 수정
* 테스트코드 실패케이스 개선